### PR TITLE
Fixed notice error passed by reference

### DIFF
--- a/ws/phpwebsocket.php
+++ b/ws/phpwebsocket.php
@@ -43,11 +43,13 @@ class phpWebSocket{
     $this->say("Master socket  : ".$this->master."\n");
 	$this->say(".... awaiting connections ...");
 	
+    $write = array();
+    $except = array();
 	// Main Server processing loop
     while(true)  //server is always listening
 	{
       $changed = $this->sockets;
-      socket_select($changed,$write=NULL,$except=NULL,NULL);
+      socket_select($changed,$write,$except,NULL);
 	  $this->say("listening...\n");
       foreach($changed as $socket)
 	  {


### PR DESCRIPTION
I get this error:
```
Notice: Only variables should be passed by reference in phpwebsocket.php on line 50
```
It's because of `socket_select` that happens, because some arguments must be array.
I fixed it.

